### PR TITLE
Except YTMusicUserError in auth.py fixes #110

### DIFF
--- a/ytmusic_deleter/auth.py
+++ b/ytmusic_deleter/auth.py
@@ -4,6 +4,7 @@ from pathlib import Path
 
 import ytmusicapi
 from ytmusicapi import YTMusic
+from ytmusicapi.exceptions import YTMusicUserError
 
 from . import common as const
 
@@ -23,7 +24,7 @@ def ensure_auth(credential_dir, oauth) -> YTMusic:
         logging.info(f"Attempting authentication with: {auth_file_path}")
         yt_auth = YTMusic(auth_file_path)
         logging.info(f'Authenticated with: {auth_file_path}"')
-    except JSONDecodeError:
+    except (JSONDecodeError, YTMusicUserError, FileNotFoundError):
         logging.info(f"Creating file: {auth_file_name}")
         if oauth:
             ytmusicapi.setup_oauth(filepath=auth_file_path, open_browser=True)


### PR DESCRIPTION
Add exceptions thrown by `ytmusicapi` to fix #110 . Tested on my local machine.

The selected line changes the exception handling in the try block. Previously, it only caught `JSONDecodeError`. The change adds `YTMusicUserError` and `FileNotFoundError` to the exceptions being caught. This means that if any of these three exceptions (`JSONDecodeError`, `YTMusicUserError`, or `FileNotFoundError`) are raised during the authentication attempt, the except block will be executed, logging the message about creating the authentication file and proceeding with the `OAuth` setup if enabled.