### PR TITLE
fix: sanitize alternating chrome headers in cli and gui

### DIFF
--- a/tests/test_cleanup.py
+++ b/tests/test_cleanup.py
@@ -1,0 +1,64 @@
+from ytmusic_deleter.common import HeaderCleanup
+
+
+def test_cleanup_standard_firefox_headers():
+    """Ensure already formatted headers are left alone."""
+    raw = "Host: music.youtube.com\nUser-Agent: Mozilla/5.0"
+    cleaned = HeaderCleanup.cleanup_headers(raw)
+    assert cleaned == raw
+
+
+def test_cleanup_chrome_alternating_headers():
+    """Ensure standard alternating Chrome headers are joined correctly."""
+    raw = "Host\nmusic.youtube.com\nAccept\n*/*"
+    expected = "Host: music.youtube.com\nAccept: */*"
+    cleaned = HeaderCleanup.cleanup_headers(raw)
+    assert cleaned == expected
+
+
+def test_cleanup_chrome_empty_values():
+    """Ensure empty header values don't shift the alternating pattern."""
+    raw = "Host\nmusic.youtube.com\nEmpty-Header\n\nAccept\n*/*"
+    cleaned = HeaderCleanup.cleanup_headers(raw)
+    assert "Host: music.youtube.com" in cleaned
+    assert "Empty-Header: " in cleaned
+    assert "Accept: */*" in cleaned
+
+
+def test_cleanup_chrome_wrapped_multiline():
+    """Ensure long values broken by terminal wrapping are stitched back together."""
+    raw = (
+        "cookie\n"
+        "LOGIN_INFO=AFmmF2swRQIgXsr\n"
+        "VISITOR_INFO1_LIVE=ulHbiv7\n"
+        "PREF=f6=80&tz=America\n"
+        "origin\n"
+        "https://music.youtube.com"
+    )
+    cleaned = HeaderCleanup.cleanup_headers(raw)
+
+    # The cookie parts should be combined into one single line
+    expected_cookie = "cookie: LOGIN_INFO=AFmmF2swRQIgXsrVISITOR_INFO1_LIVE=ulHbiv7PREF=f6=80&tz=America"
+
+    assert expected_cookie in cleaned
+    assert "origin: https://music.youtube.com" in cleaned
+
+
+def test_client_variations_removal():
+    """Ensure the giant Decoded ClientVariations block is stripped out."""
+    raw = (
+        "x-client-data\n"
+        "CLO1yQEIlbbJA\n"
+        "Decoded:\n"
+        "message ClientVariations {\n"
+        "  repeated int32 variation_id = [3300019];\n"
+        "}\n"
+        "x-goog-authuser\n"
+        "0"
+    )
+    cleaned = HeaderCleanup.cleanup_headers(raw)
+
+    assert "Decoded:" not in cleaned
+    assert "message ClientVariations" not in cleaned
+    assert "x-client-data: CLO1yQEIlbbJA" in cleaned
+    assert "x-goog-authuser: 0" in cleaned

--- a/ytmusic_deleter/auth.py
+++ b/ytmusic_deleter/auth.py
@@ -1,4 +1,5 @@
 import logging
+import sys
 from json import JSONDecodeError
 from pathlib import Path
 
@@ -37,7 +38,7 @@ def do_auth(
             raise RuntimeError("Authentication failed")
         logging.info(f"Authenticated with: {auth_file_path}")
         logging.info(
-            f"Signed in using {"OAuth" if oauth else "browser authentication"} as {yt_auth.get_account_info().get('accountName')!r}"
+            f"Signed in using {'OAuth' if oauth else 'browser authentication'} as {yt_auth.get_account_info().get('accountName')!r}"
         )
     return yt_auth
 
@@ -57,7 +58,12 @@ def _setup_auth(oauth: bool, client_id: str, client_secret: str, auth_file_path:
             open_browser=True,
         )
     else:
-        ytmusicapi.setup(filepath=auth_file_path)
+        click.echo(
+            "Please paste the request headers from your browser and press Ctrl-D (or Ctrl-Z on Windows) to continue:"
+        )
+        headers_raw = sys.stdin.read()
+        cleaned_headers = const.HeaderCleanup.cleanup_headers(headers_raw)
+        ytmusicapi.setup(filepath=auth_file_path, headers_raw=cleaned_headers)
 
 
 def _authenticate(auth_file_path: str, oauth: bool, client_id: str, client_secret: str) -> ytmusicapi.YTMusic:

--- a/ytmusic_deleter/common.py
+++ b/ytmusic_deleter/common.py
@@ -149,7 +149,7 @@ class HeaderCleanup:
             else:
                 # Chrome copies header names as strictly lowercase alphanumeric/hyphens.
                 # If a line has uppercase, semicolons, etc., it's a wrapped fragment of the previous value!
-                is_header_format = bool(line and re.match(r"^[a-z0-9\-]+$", line) and len(line) < 50)
+                is_header_format = bool(line and re.match(r"^[A-Za-z0-9\-]+$", line) and len(line) < 50)
 
                 if is_header_format:
                     result.append(f"{current_header}: {''.join(current_value)}")

--- a/ytmusic_deleter/common.py
+++ b/ytmusic_deleter/common.py
@@ -129,23 +129,39 @@ class HeaderCleanup:
         if HeaderCleanup.is_already_formatted(header_lines):
             logging.debug("Headers are already formatted, returning as is.")
             return header_lines.strip()
+
         header_lines = HeaderCleanup.remove_client_variations_block(header_lines)
         logging.debug("Headers after removing ClientVariations block:\n%s", header_lines)
-        lines = header_lines.splitlines()
 
-        # Remove empty lines
-        lines = [line.strip() for line in lines if line.strip()]
+        header_lines = header_lines.strip()
+        lines = [line.strip() for line in header_lines.splitlines()]
 
         result = []
-        i = 0
-        while i < len(lines) - 1:
-            header = lines[i]
-            value = lines[i + 1]
-            result.append(f"{header}: {value}")
-            i += 2
-        # Handle odd number of lines
-        if i < len(lines):
-            result.append(lines[i])
+        current_header = None
+        current_value = []
+
+        for line in lines:
+            if current_header is None:
+                current_header = line
+            elif not current_value:
+                # The very first line after the header is unconditionally part of the value
+                current_value.append(line)
+            else:
+                # Chrome copies header names as strictly lowercase alphanumeric/hyphens.
+                # If a line has uppercase, semicolons, etc., it's a wrapped fragment of the previous value!
+                is_header_format = bool(line and re.match(r"^[a-z0-9\-]+$", line) and len(line) < 50)
+
+                if is_header_format:
+                    result.append(f"{current_header}: {''.join(current_value)}")
+                    current_header = line
+                    current_value = []
+                else:
+                    current_value.append(line)
+
+        # Append the final item
+        if current_header is not None:
+            result.append(f"{current_header}: {''.join(current_value)}")
+
         joined_result = "\n".join(result)
         logging.debug("Formatted headers:\n%s", joined_result)
         return joined_result
@@ -190,19 +206,16 @@ class HeaderCleanup:
     @staticmethod
     def is_already_formatted(header_text: str) -> bool:
         """
-        Returns True if either of the first two non-empty lines contains a colon followed by at least one
-        non-space character, indicating it's already formatted as 'Header: Value'.
+        Returns True if the text is already formatted as 'Header: Value'.
         """
-        checked = 0
-        for line in header_text.splitlines():
-            line = line.strip()
-            if not line:
-                continue
-            checked += 1
-            if ":" in line:
-                parts = line.split(":", 1)
-                if parts[1].strip():
-                    return True
-            if checked >= 2:
-                break
-        return False
+        lines = [line.strip() for line in header_text.splitlines() if line.strip()]
+        if not lines:
+            return False
+
+        # Check up to the first 4 non-empty lines
+        lines_to_check = lines[:4]
+        colon_count = sum(1 for line in lines_to_check if ":" in line)
+
+        # Firefox (formatted) has a colon on every line.
+        # Chrome (alternating) has colons on half or fewer lines.
+        return colon_count > (len(lines_to_check) / 2)


### PR DESCRIPTION
# fix: sanitize alternating chrome headers in cli and gui

## 📖 Description
This PR fixes a bug where raw request headers copied from Google Chrome would cause the authentication setup to crash, particularly when using the CLI. 

### **The Problem**
When users copy headers from Chrome, they are pasted as alternating lines (e.g., `HeaderName` on line 1, `HeaderValue` on line 2). Furthermore, if a header has an empty value, Chrome sometimes copies it as a blank line, and terminal line-wrapping can break long values (like `cookie`) into multiple fragmented lines. 

The underlying `ytmusicapi` natively expects Firefox-formatted headers (`Header: Value`) and fails to parse Chrome's raw output. While the GUI had a basic `HeaderCleanup` utility, it was stripping empty lines (causing value shifts) and the CLI was bypassing it entirely.

### **The Solution**
1. **Updated `HeaderCleanup` (in `common.py`):** Rewrote the parser to dynamically stitch together fragmented, multi-line values by evaluating if a line is a valid lowercase header name. It now also safely handles empty header values without shifting the dictionary pairs.
2. **Intercepted CLI Prompt (in `auth.py`):** The CLI's `_setup_auth` function now intercepts the user's `stdin`, passes the raw headers through `HeaderCleanup.cleanup_headers()`, and feeds the sanitized `Header: Value` string to `ytmusicapi`.
3. **Added Unit Tests (`tests/test_cleanup.py`):** Implemented a new suite of pure unit tests covering standard, alternating, empty-value, and multi-line header scenarios to ensure parsing logic remains robust.
---

## 🧪 How to Test
1. Run `pdm run ytmusic-deleter remove-duplicates`
2. Paste raw, alternating headers copied directly from Google Chrome (including a long, multi-line `cookie` string).
3. Verify that authentication succeeds instead of throwing a `YTMusicUserError: Invalid auth JSON string or file path provided.`

---

## ⚠️ Note on Automated Testing
I observed that the automated `pytest` suite resulted in several failures and excessive execution times during local testing. These failures appear to stem from:
* Tests expecting specific strings in API replies that no longer match current YouTube Music responses.
* Environmental quirks and persistent retry loops unrelated to the logic changed in this PR (tests attempting thousands of retries).

Because of this, I relied on **manual testing**. I confirmed that:
* Pasting raw, alternating Chrome headers (including multi-line fragments) authenticates perfectly in both the CLI and the GUI.
* Standard Firefox-formatted headers continue to work as expected.

Please let me know if you need me to adjust anything

**Update**: I noticed the initial Codecov report flagged low patch coverage for the new logic. I've just pushed a new commit adding a dedicated unit test suite (tests/test_cleanup.py) that covers the standard, alternating, and multi-line header scenarios.