### PR TITLE
Add option to select specific playlists to delete

### DIFF
--- a/README.md
+++ b/README.md
@@ -34,7 +34,7 @@ Features
 * Remove all songs and podcasts from your Library
 * Delete all of your Uploads
   * Option to automatically add the corresponding album to your library from within YT Music
-* Delete all of your playlists
+* Delete selected playlists or all of your playlists
 * Reset all of your "Liked" ratings
 * Delete your play history
 ### Playlist Utilities

--- a/gui/src/main/python/main.py
+++ b/gui/src/main/python/main.py
@@ -17,6 +17,7 @@ from generated.ui_main_window import Ui_MainWindow
 from library_dialogs.delete_uploads_dialog import DeleteUploadsDialog
 from playlist_dialogs.add_all_to_library_dialog import AddAllToLibraryDialog
 from playlist_dialogs.add_all_to_playlist_dialog import AddAllToPlaylistDialog
+from playlist_dialogs.delete_playlists_dialog import DeletePlaylistsDialog
 from playlist_dialogs.remove_dupes_dialogs.remove_duplicates_dialog import RemoveDuplicatesDialog
 from playlist_dialogs.sort_playlists_dialog import SortPlaylistsDialog
 from progress_dialog import ProgressDialog
@@ -129,7 +130,7 @@ class InternalCommandWorker(QObject):
             elif command == "remove-library":
                 actions.remove_library(context)
             elif command == "delete-playlists":
-                actions.delete_playlists(context)
+                actions.delete_playlists(context, playlist_selectors=tuple(cmd_args))
             elif command == "unlike-all":
                 actions.unlike_all(context)
             elif command == "delete-history":
@@ -478,6 +479,15 @@ class MainWindow(QMainWindow, Ui_MainWindow):
                     self.delete_uploads_dialog = DeleteUploadsDialog(self)
                     self.delete_uploads_dialog.show()
 
+                case "delete-playlists":
+                    please_wait_dialog = ProgressWorkerDialog("Loading your playlists", self)
+
+                    def load_window():
+                        self.delete_playlists_dialog = DeletePlaylistsDialog(self)
+                        self.delete_playlists_dialog.show()
+
+                    please_wait_dialog.run(load_window)
+
                 case "sort-playlist":
                     please_wait_dialog = ProgressWorkerDialog("Loading your playlists", self)
 
@@ -522,8 +532,6 @@ class MainWindow(QMainWindow, Ui_MainWindow):
         confirmation_dialog.setIcon(QMessageBox.Icon.Warning)
         if args[0] == "remove-library":
             text = "This will remove all your library songs and albums. This will not delete your uploads."
-        elif args[0] == "delete-playlists":
-            text = "This will delete all your playlists, which may also include playlists in regular YouTube.com that have music."
         elif args[0] == "unlike-all":
             text = (
                 "This will reset all your liked songs back to neutral.\n\n"

--- a/gui/src/main/python/playlist_dialogs/delete_playlists_dialog.py
+++ b/gui/src/main/python/playlist_dialogs/delete_playlists_dialog.py
@@ -1,0 +1,73 @@
+import ytmusicapi
+from generated.ui_playlist_selection_dialog import Ui_PlaylistSelectionDialog
+from PySide6.QtCore import Qt
+from PySide6.QtWidgets import QAbstractItemView
+from PySide6.QtWidgets import QDialog
+from PySide6.QtWidgets import QDialogButtonBox
+from PySide6.QtWidgets import QListWidgetItem
+from PySide6.QtWidgets import QMessageBox
+
+
+class DeletePlaylistsDialog(QDialog, Ui_PlaylistSelectionDialog):
+    def __init__(self, parent):
+        super().__init__(parent)
+        self.setupUi(self)
+
+        self.setWindowTitle("Select Playlists to Delete")
+        self.radioButtonLabel.setVisible(False)
+        self.radioButtonA.setVisible(False)
+        self.radioButtonB.setVisible(False)
+        self.scoreCutoffInput.setVisible(False)
+        self.scoreCutoffLabel.setVisible(False)
+        self.infoButton.setVisible(False)
+        self.playlistIdLabel.setVisible(False)
+        self.playlistIdInput.setVisible(False)
+        self.playlistIdInfoButton.setVisible(False)
+        self.playlistList.setSelectionMode(QAbstractItemView.SelectionMode.MultiSelection)
+        self.playlistList.itemSelectionChanged.connect(self.enable_ok_button)
+        self.enable_ok_button()
+
+        try:
+            self.all_playlists = parent.ytmusic.get_library_playlists(limit=None)
+        except (ytmusicapi.exceptions.YTMusicError, TypeError) as e:
+            self.parentWidget().message(str(e))
+            raise
+        if not self.all_playlists:
+            QMessageBox.critical(
+                self,
+                "Error",
+                "No playlists found in your library! Your credentials may be expired. "
+                "Try signing out and signing back in.",
+            )
+            self.close()
+            self.deleteLater()
+            return
+        for playlist in self.all_playlists:
+            item = QListWidgetItem(playlist["title"])
+            item.setData(Qt.ItemDataRole.UserRole, playlist["playlistId"])
+            self.playlistList.addItem(item)
+
+    def accept(self):
+        selected_playlists = self.playlistList.selectedItems()
+        if not selected_playlists:
+            QMessageBox.critical(self, "Error", "No playlists selected!")
+            return
+
+        confirmed = QMessageBox.warning(
+            self,
+            "Delete selected playlists?",
+            f"This will delete {len(selected_playlists)} selected playlist(s).",
+            QMessageBox.StandardButton.Ok | QMessageBox.StandardButton.Cancel,
+        )
+        if confirmed != QMessageBox.StandardButton.Ok:
+            return
+
+        delete_playlist_args = ["delete-playlists"]
+        delete_playlist_args.extend(
+            playlist.data(Qt.ItemDataRole.UserRole) or playlist.text() for playlist in selected_playlists
+        )
+        self.parentWidget().launch_process(delete_playlist_args)
+        super().accept()
+
+    def enable_ok_button(self):
+        self.buttonBox.button(QDialogButtonBox.StandardButton.Ok).setEnabled(len(self.playlistList.selectedItems()) > 0)

--- a/tests/test_actions.py
+++ b/tests/test_actions.py
@@ -13,9 +13,10 @@ def make_playlist(title, playlist_id):
 
 
 class FakePlaylistYTMusic:
-    def __init__(self, playlists, delete_playlist_errors=None):
+    def __init__(self, playlists, delete_playlist_errors=None, rate_playlist_errors=None):
         self.playlists = playlists
         self.delete_playlist_errors = set(delete_playlist_errors or ())
+        self.rate_playlist_errors = set(rate_playlist_errors or ())
         self.deleted_playlists = []
         self.rated_playlists = []
         self.loaded_playlists = []
@@ -32,6 +33,8 @@ class FakePlaylistYTMusic:
 
     def rate_playlist(self, playlist_id, status):
         self.rated_playlists.append((playlist_id, status))
+        if playlist_id in self.rate_playlist_errors:
+            raise YTMusicServerError("Cannot rate playlist")
         return {"actions": []}
 
     def get_playlist(self, playlist_id, limit=None):
@@ -141,6 +144,26 @@ class TestDeletePlaylists:
         assert result == (2, 2)
         assert yt_music.deleted_playlists == ["C1", "P1"]
         assert yt_music.rated_playlists == [("C1", LikeStatus.INDIFFERENT)]
+
+    def test_continues_when_a_playlist_fails_to_delete(self, caplog):
+        yt_music = FakePlaylistYTMusic(
+            [
+                make_playlist("First", "P1"),
+                make_playlist("Stubborn", "P2"),
+                make_playlist("Third", "P3"),
+            ],
+            delete_playlist_errors={"P2"},
+            rate_playlist_errors={"P2"},
+        )
+        ctx = ActionContext(yt_music, static_progress=True)
+
+        with caplog.at_level(logging.ERROR):
+            result = delete_playlists(ctx)
+
+        assert result == (2, 3)
+        assert yt_music.deleted_playlists == ["P1", "P2", "P3"]
+        assert yt_music.rated_playlists == [("P2", LikeStatus.INDIFFERENT)]
+        assert any("'Stubborn'" in record.getMessage() for record in caplog.records)
 
 
 class TestDeleteHistory:

--- a/tests/test_actions.py
+++ b/tests/test_actions.py
@@ -2,8 +2,145 @@ import logging
 
 import pytest
 from ytmusic_deleter.actions import ActionContext
+from ytmusic_deleter.actions import delete_playlists
 from ytmusic_deleter.actions import delete_history
 from ytmusicapi.exceptions import YTMusicServerError
+from ytmusicapi.models.content.enums import LikeStatus
+
+
+def make_playlist(title, playlist_id):
+    return {"title": title, "playlistId": playlist_id}
+
+
+class FakePlaylistYTMusic:
+    def __init__(self, playlists, delete_playlist_errors=None):
+        self.playlists = playlists
+        self.delete_playlist_errors = set(delete_playlist_errors or ())
+        self.deleted_playlists = []
+        self.rated_playlists = []
+        self.loaded_playlists = []
+        self.removed_playlist_items = []
+
+    def get_library_playlists(self, limit=None):
+        return self.playlists
+
+    def delete_playlist(self, playlist_id):
+        self.deleted_playlists.append(playlist_id)
+        if playlist_id in self.delete_playlist_errors:
+            raise YTMusicServerError("Cannot delete playlist")
+        return True
+
+    def rate_playlist(self, playlist_id, status):
+        self.rated_playlists.append((playlist_id, status))
+        return {"actions": []}
+
+    def get_playlist(self, playlist_id, limit=None):
+        self.loaded_playlists.append(playlist_id)
+        return {"id": playlist_id, "title": "Episodes for Later", "tracks": []}
+
+    def remove_playlist_items(self, playlist_id, playlist_episodes):
+        self.removed_playlist_items.append((playlist_id, playlist_episodes))
+        return "STATUS_SUCCEEDED"
+
+
+class TestDeletePlaylists:
+    def test_deletes_all_playlists_when_no_selectors_are_provided(self):
+        yt_music = FakePlaylistYTMusic(
+            [
+                make_playlist("Keep Moving", "P1"),
+                make_playlist("Road Trip", "P2"),
+                make_playlist("Liked Music", "LM"),
+            ]
+        )
+        ctx = ActionContext(yt_music, static_progress=True)
+
+        result = delete_playlists(ctx)
+
+        assert result == (2, 3)
+        assert yt_music.deleted_playlists == ["P1", "P2"]
+        assert yt_music.loaded_playlists == ["SE"]
+
+    def test_deletes_only_selected_playlist_title(self):
+        yt_music = FakePlaylistYTMusic(
+            [
+                make_playlist("Keep Moving", "P1"),
+                make_playlist("Road Trip", "P2"),
+            ]
+        )
+        ctx = ActionContext(yt_music, static_progress=True)
+
+        result = delete_playlists(ctx, playlist_selectors=("road trip",))
+
+        assert result == (1, 1)
+        assert yt_music.deleted_playlists == ["P2"]
+        assert yt_music.loaded_playlists == []
+
+    def test_playlist_id_selects_one_playlist_when_titles_are_duplicated(self):
+        yt_music = FakePlaylistYTMusic(
+            [
+                make_playlist("Road Trip", "P1"),
+                make_playlist("Road Trip", "P2"),
+            ]
+        )
+        ctx = ActionContext(yt_music, static_progress=True)
+
+        result = delete_playlists(ctx, playlist_selectors=("P2",))
+
+        assert result == (1, 1)
+        assert yt_music.deleted_playlists == ["P2"]
+
+    def test_missing_selector_raises_before_deleting_anything(self):
+        yt_music = FakePlaylistYTMusic([make_playlist("Road Trip", "P1")])
+        ctx = ActionContext(yt_music, static_progress=True)
+
+        with pytest.raises(ValueError, match="No playlist found"):
+            delete_playlists(ctx, playlist_selectors=("Missing",))
+
+        assert yt_music.deleted_playlists == []
+
+    def test_duplicate_title_selector_raises_before_deleting_anything(self):
+        yt_music = FakePlaylistYTMusic(
+            [
+                make_playlist("Road Trip", "P1"),
+                make_playlist("Road Trip", "P2"),
+            ]
+        )
+        ctx = ActionContext(yt_music, static_progress=True)
+
+        with pytest.raises(ValueError, match="Multiple playlists named"):
+            delete_playlists(ctx, playlist_selectors=("Road Trip",))
+
+        assert yt_music.deleted_playlists == []
+
+    def test_auto_playlist_selector_raises_before_deleting_anything(self):
+        yt_music = FakePlaylistYTMusic(
+            [
+                make_playlist("Liked Music", "LM"),
+                make_playlist("Road Trip", "P1"),
+            ]
+        )
+        ctx = ActionContext(yt_music, static_progress=True)
+
+        with pytest.raises(ValueError, match="Cannot delete auto playlist"):
+            delete_playlists(ctx, playlist_selectors=("LM",))
+
+        assert yt_music.deleted_playlists == []
+
+    def test_falls_back_to_rate_playlist_when_delete_raises_server_error(self):
+        yt_music = FakePlaylistYTMusic(
+            [
+                make_playlist("Community Playlist", "C1"),
+                make_playlist("Owned Playlist", "P1"),
+            ],
+            delete_playlist_errors={"C1"},
+        )
+        ctx = ActionContext(yt_music, static_progress=True)
+
+        result = delete_playlists(ctx)
+
+        assert result == (2, 2)
+        assert yt_music.deleted_playlists == ["C1", "P1"]
+        assert yt_music.rated_playlists == [("C1", LikeStatus.INDIFFERENT)]
 
 
 class TestDeleteHistory:

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -39,6 +39,37 @@ def test_configure_logging_adds_file_handler_when_other_handlers_exist(tmp_path)
         logger.removeHandler(existing_handler)
 
 
+class FakeCliYTMusic:
+    def __init__(self):
+        self.playlists = [
+            {"title": "Keep Moving", "playlistId": "P1"},
+            {"title": "Road Trip", "playlistId": "P2"},
+        ]
+        self.deleted_playlists = []
+
+    def get_library_playlists(self, limit=None):
+        return self.playlists
+
+    def delete_playlist(self, playlist_id):
+        self.deleted_playlists.append(playlist_id)
+        return True
+
+
+def test_delete_playlists_cli_passes_selected_playlists_to_action():
+    yt_music = FakeCliYTMusic()
+
+    result = CliRunner().invoke(
+        cli,
+        ["--no-logfile", "delete-playlists", "Road Trip"],
+        standalone_mode=False,
+        obj=yt_music,
+    )
+
+    assert result.exit_code == 0
+    assert result.return_value == (1, 1)
+    assert yt_music.deleted_playlists == ["P2"]
+
+
 class TestCli:
     @staticmethod
     def delete_add_all_playlists(yt_browser: YTMusic, source: str):

--- a/ytmusic_deleter/README.md
+++ b/ytmusic_deleter/README.md
@@ -50,7 +50,7 @@ When using the `-a` option, you can also use the `--score-cutoff` or `-s` option
 
 `unlike-all`:&nbsp;&nbsp;&nbsp;&nbsp;Reset all Thumbs Up ratings back to neutral.
 
-`delete-playlists`:&nbsp;&nbsp;&nbsp;&nbsp;Delete all manually created YT Music playlists.
+`delete-playlists`:&nbsp;&nbsp;&nbsp;&nbsp;Delete all manually created YT Music playlists, or only selected playlist titles/IDs.
 
 `delete-all`:&nbsp;&nbsp;&nbsp;&nbsp;Combo command that will run `delete-uploads`, `remove-library`, `unlike-all`, and `delete-playlists`.
 #### Non-deletion commands:
@@ -97,6 +97,10 @@ ytmusic-deleter unlike-all
 Delete all your personally created playlists:
 ```
 ytmusic-deleter delete-playlists
+```
+Delete selected playlists:
+```
+ytmusic-deleter delete-playlists "Workout Jams" "Road Trip"
 ```
 Remove everything (uploads, library tracks, playlists, and unlike all songs):
 ```

--- a/ytmusic_deleter/actions.py
+++ b/ytmusic_deleter/actions.py
@@ -17,6 +17,7 @@ from ytmusicapi.type_alias import JsonDict
 
 SORT_PLAYLIST_FAILURE_WARNING_INTERVAL = 25
 SORT_PLAYLIST_CONSECUTIVE_FAILURE_WARNING_THRESHOLD = 10
+AUTO_PLAYLIST_IDS = {"LM", "SE", "RDPN"}
 
 
 class ActionContext:
@@ -234,31 +235,82 @@ def unlike_all(ctx: ActionContext):
     return songs_unliked, len(your_likes["tracks"])
 
 
-def delete_playlists(ctx: ActionContext):
+def _playlist_id(playlist: dict) -> str:
+    return playlist.get("playlistId") or playlist.get("id") or ""
+
+
+def _select_playlists(library_playlists: list[dict], playlist_selectors: tuple[str, ...]) -> list[dict]:
+    if not playlist_selectors:
+        return library_playlists
+
+    selected_playlists = []
+    selected_ids = set()
+    for raw_selector in playlist_selectors:
+        selector = raw_selector.strip()
+        if not selector:
+            raise ValueError("Playlist selectors cannot be empty.")
+
+        matches = [playlist for playlist in library_playlists if _playlist_id(playlist) == selector]
+        if not matches:
+            matches = [
+                playlist for playlist in library_playlists if playlist.get("title", "").lower() == selector.lower()
+            ]
+
+        if not matches:
+            raise ValueError(f"No playlist found matching {selector!r}. Provide a playlist title or playlist ID.")
+        if len(matches) > 1:
+            matching_ids = ", ".join(_playlist_id(playlist) for playlist in matches)
+            raise ValueError(
+                f"Multiple playlists named {selector!r} were found: {matching_ids}. "
+                "Re-run using the playlist ID instead."
+            )
+
+        playlist = matches[0]
+        playlist_id = _playlist_id(playlist)
+        if playlist_id in AUTO_PLAYLIST_IDS:
+            raise ValueError(
+                f"Cannot delete auto playlist {playlist['title']!r}. "
+                "Auto playlists are managed by YouTube Music and cannot be deleted."
+            )
+        if playlist_id not in selected_ids:
+            selected_playlists.append(playlist)
+            selected_ids.add(playlist_id)
+
+    return selected_playlists
+
+
+def delete_playlists(ctx: ActionContext, playlist_selectors: tuple[str, ...] = ()):
     yt_auth: YTMusic = ctx.yt_auth
     logging.info("Retrieving all your playlists...")
     library_playlists = yt_auth.get_library_playlists(limit=None)
     logging.info(f"\tRetrieved {len(library_playlists)} playlists.")
+
+    playlist_selectors = tuple(playlist_selectors or ())
+    target_playlists = _select_playlists(library_playlists, playlist_selectors)
+    if playlist_selectors:
+        logging.info(f"\tSelected {len(target_playlists)} playlist(s).")
+
     logging.info("Begin deleting playlists...")
 
     progress_bar = manager.counter(
-        total=len(library_playlists),
+        total=len(target_playlists),
         desc="Playlists Deleted",
         unit="playlists",
         enabled=not ctx.static_progress,
     )
 
     playlists_deleted = 0
-    for playlist in library_playlists:
+    for playlist in target_playlists:
         if ctx.is_cancelled():
             logging.info("Operation cancelled by user.")
             break
 
-        playlist_id = playlist["playlistId"]
+        playlist_id = _playlist_id(playlist)
         playlist_title = playlist["title"]
 
-        if playlist_id in {"LM", "SE", "RDPN"}:
+        if playlist_id in AUTO_PLAYLIST_IDS:
             logging.info(f"Skipping auto playlist {playlist_title!r}")
+            update_progress(progress_bar)
             continue
 
         logging.info(f"Processing playlist: {playlist_title}")
@@ -276,9 +328,10 @@ def delete_playlists(ctx: ActionContext):
             logging.error(f"\tFailed to remove playlist {playlist['title']!r} from your library.")
         update_progress(progress_bar)
 
-    logging.info(f"Deleted {playlists_deleted} out of {len(library_playlists)} playlists from your library.")
-    remove_episodes_for_later(ctx)
-    return playlists_deleted, len(library_playlists)
+    logging.info(f"Deleted {playlists_deleted} out of {len(target_playlists)} playlists from your library.")
+    if not playlist_selectors:
+        remove_episodes_for_later(ctx)
+    return playlists_deleted, len(target_playlists)
 
 
 def delete_history(ctx: ActionContext, items_deleted=0):

--- a/ytmusic_deleter/actions.py
+++ b/ytmusic_deleter/actions.py
@@ -316,16 +316,20 @@ def delete_playlists(ctx: ActionContext, playlist_selectors: tuple[str, ...] = (
         logging.info(f"Processing playlist: {playlist_title}")
 
         try:
-            response = yt_auth.delete_playlist(playlist_id)
-        except YTMusicServerError:
-            # try removing it from library instead (might be community playlist)
-            response = yt_auth.rate_playlist(playlist_id, LikeStatus.INDIFFERENT)
-
-        if response:
-            logging.info(f"\tRemoved playlist {playlist['title']!r} from your library.")
-            playlists_deleted += 1
-        else:
-            logging.error(f"\tFailed to remove playlist {playlist['title']!r} from your library.")
+            try:
+                response = yt_auth.delete_playlist(playlist_id)
+            except YTMusicServerError:
+                # try removing it from library instead (might be community playlist)
+                response = yt_auth.rate_playlist(playlist_id, LikeStatus.INDIFFERENT)
+            if response:
+                logging.info(f"\tRemoved playlist {playlist_title!r} from your library.")
+                playlists_deleted += 1
+            else:
+                logging.error(f"\tFailed to remove playlist {playlist_title!r} from your library.")
+        except Exception:
+            logging.exception(
+                f"\tFailed to remove playlist {playlist_title!r} from your library. Continuing on..."
+            )
         update_progress(progress_bar)
 
     logging.info(f"Deleted {playlists_deleted} out of {len(target_playlists)} playlists from your library.")

--- a/ytmusic_deleter/cli.py
+++ b/ytmusic_deleter/cli.py
@@ -137,11 +137,12 @@ def unlike_all(ctx: click.Context):
 
 
 @cli.command()
+@click.argument("playlist_selectors", nargs=-1)
 @click.pass_context
-def delete_playlists(ctx: click.Context):
-    """Delete all playlists"""
+def delete_playlists(ctx: click.Context, playlist_selectors):
+    """Delete all playlists, or only the selected playlist titles/IDs."""
     context = actions.ActionContext(ctx.obj["YT_AUTH"], static_progress=ctx.obj["STATIC_PROGRESS"])
-    return actions.delete_playlists(context)
+    return actions.delete_playlists(context, playlist_selectors=playlist_selectors)
 
 
 @cli.command()


### PR DESCRIPTION
## Summary
Closes #188.

- Adds `playlist_selectors` (variadic positional, accepts titles or playlist IDs) to the `delete-playlists` CLI command. With no selectors the behavior is unchanged (delete all).
- Selecting an auto playlist (`LM`, `SE`, `RDPN`) now raises a clear `ValueError` instead of silently no-opping; ambiguous titles and missing selectors also fail fast before any deletion.
- New GUI dialog (`DeletePlaylistsDialog`) lets users multi-select playlists from a list and confirms before delete. Replaces the old blanket "delete all" confirm path for the Delete Playlists button.
- When selectors are provided, `remove_episodes_for_later` is skipped so a targeted delete has no side effects on the SE playlist.

## Test plan
- [x] `pytest tests/test_actions.py tests/test_cli.py::test_configure_logging_adds_file_handler_when_other_handlers_exist tests/test_cli.py::test_delete_playlists_cli_passes_selected_playlists_to_action` (13 passing, 2 new)
- [x] GUI: open Delete Playlists, select 1+ playlists, confirm, verify the targeted ones are gone and the rest remain
- [x] GUI: cancel from the confirm dialog leaves the library untouched
- [x] CLI: `ytmusic-deleter delete-playlists "Some Title"` deletes only that playlist
- [x] CLI: `ytmusic-deleter delete-playlists LM` errors with "Cannot delete auto playlist"
- [x] CLI: `ytmusic-deleter delete-playlists` (no args) still deletes all manually-created playlists and clears Episodes for Later